### PR TITLE
Add pip to apt packages

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,6 +6,7 @@ barman_apt_packages:
   - python
   - python-psycopg2
   - python-pycurl
+  - python-pip
 
 barman_pip_packages:
   - argcomplete


### PR DESCRIPTION
Install `python-pip from apt`

Issue that I ran into without pip installed
![image](https://user-images.githubusercontent.com/5580824/54946673-06480e00-4f0f-11e9-93d8-106a10e4b6fd.png)
