### PR TITLE
Fix streaming wals and other improvements

### DIFF
--- a/templates/server.conf.j2
+++ b/templates/server.conf.j2
@@ -3,75 +3,67 @@ active = "{{ item.active | default(true)}}"
 ; Human readable description
 description = "{{ item.description }}"
 
-{% if item.backup_method == 'rsync' -%}
 ; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; SSH options (mandatory)
+; PostgreSQL connection strings
 ; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-ssh_command = ssh {{ item.backup_user }}@{{ item.host }}
-{%- endif %}
 
-
-; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; PostgreSQL connection string (mandatory)
-; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; conninfo is mandatory in all options of backup and WAL shipping
 conninfo = "host={{ item.host}} user={{ item.backup_user }} dbname={{ item.systemdbname}}"
 
-{% if item.backup_method == 'postgres' -%}
-; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; PostgreSQL streaming connection string
-; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; streaming_conninfo is required when streaming either backups or WALs
 ; To be used by pg_basebackup for backup and pg_receivexlog for WAL streaming
 ; NOTE: streaming_barman is a regular user with REPLICATION privilege
 streaming_conninfo = "host={{ item.host}} user={{ item.streaming_user }} dbname={{ item.systemdbname}}"
-{%- endif %}
+
+
+{% if item.backup_method is defined -%}
+backup_method = "{{ item.backup_method }}"
+{% endif %}
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; BACKUP - can be one of either postgres (via pg_basebackup) or rsync (via SSH)
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 {% if item.backup_method == 'rsync' -%}
 ; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Backup settings (via rsync over SSH)
+; Backup Option 1: rsync backup
 ; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-{% if item.backup_method is defined -%}
-backup_method = "{{ item.backup_method }}"
+{% if item.ssh_command is defined %}
+ssh_command = "{{ item.ssh_command }}"
+{%- else %}
+ssh_command = ssh {{ item.backup_user }}@{{ item.host }}
 {%- endif %}
+
 ; Incremental backup support: possible values are None (default), link or copy
 {% if item.reuse_backup is defined -%}
 reuse_backup = "{{ item.reuse_backup }}"
 {%- endif %}
+
 ; Identify the standard behavior for backup operations: possible values are
 ; exclusive_backup (default), concurrent_backup
 {% if item.backup_options is defined -%}
 backup_options = "{{ item.backup_options }}"
 {%- endif %}
-{%- endif %}
 
-{% if item.backup_method == 'postgres' -%}
+{% else -%}
 ; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Backup settings (via pg_basebackup)
+; Backup Option 2: PostgreSQL streaming
 ; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-backup_method = postgres
+
 {% if item.streaming_backup_name is defined -%}
 streaming_backup_name = "{{ item.streaming_backup_name }}"
 {%- endif %}
 {%- endif %}
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; WAL SHIPPING - can be streaming (replication) or traditional archiving, or both
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-{% if item.backup_method == 'rsync' -%}
+{% if item.streaming_archiver is defined and item.streaming_archiver == 'on' -%}
 ; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Continuous WAL archiving (via 'archive_command')
+; WAL Shipping Option 1: PostgreSQL streaming
 ; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-archiver = {{ item.archiver | default('on')}}
-{% if item.archiver_batch_size is defined -%}
-archiver_batch_size = {{ item.archiver_batch_size }}
-{%- endif %}
-{%- endif %}
-
-
-{% if item.backup_method == 'postgres' -%}
-; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; WAL streaming settings (via pg_receivexlog)
-; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-{% if item.streaming_archiver is defined -%}
 streaming_archiver = "{{ item.streaming_archiver }}"
-{%- endif %}
 
 {% if item.slot_name is defined -%}
 slot_name = "{{ item.slot_name }}"
@@ -84,130 +76,137 @@ streaming_archiver_name = "{{ item.streaming_archiver_name }}"
 {% if item.streaming_archiver_batch_size is defined -%}
 streaming_archiver_batch_size = "{{ item.streaming_archiver_batch_size }}"
 {%- endif %}
-
 {%- endif %}
 
+; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; WAL Shipping Option 2: traditional archiving
+; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+archiver = {{ item.archiver | default('on')}}
+{% if item.archiver_batch_size is defined -%}
+archiver_batch_size = {{ item.archiver_batch_size }}
+
+{%- endif %}
 {% if item.path_prefix is defined -%}
 ; PATH setting for this server
 path_prefix = "{{ item.path_prefix }}"
-{%- endif %}
 
+{%- endif %}
 {% if item.incoming_wals_directory is defined -%}
 incoming_wals_directory = "{{ item.incoming_wals_directory}}"
-{%- endif %}
 
+{%- endif %}
 {% if item.streaming_wals_directory is defined -%}
 streaming_wals_directory = "{{ item.streaming_wals_directory }}"
-{%- endif %}
 
+{%- endif %}
 {% if item.wals_directory is defined -%}
 wals_directory = "{{ item.wals_directory }}"
-{%- endif %}
 
+{%- endif %}
 {% if item.backup_directory is defined -%}
 backup_directory = "{{ item.backup_directory }}"
-{%- endif %}
 
+{%- endif %}
 {% if item.basebackups_directory is defined -%}
 basebackups_directory = "{{ item.basebackups_directory }}"
-{%- endif %}
 
+{%- endif %}
 {% if item.errors_directory is defined -%}
 errors_directory = "{{ item.errors_directory }}"
-{%- endif %}
 
+{%- endif %}
 {% if item.bandwidth_limit is defined -%}
 bandwidth_limit = "{{ item.bandwidth_limit }}"
-{%- endif %}
 
+{%- endif %}
 {% if item.basebackup_retry_sleep is defined -%}
 basebackup_retry_sleep = "{{ item.basebackup_retry_sleep }}"
-{%- endif %}
 
+{%- endif %}
 {% if item.basebackup_retry_times is defined -%}
 basebackup_retry_times = "{{ item.basebackup_retry_times }}"
-{%- endif %}
 
-{% if item.check_timeout is defined -%}
+{%- endif %}
+{%- if item.check_timeout is defined %}
 check_timeout = "{{ item.check_timeout }}"
-{%- endif %}
 
-{% if item.compression is defined -%}
+{%- endif %}
+{%- if item.compression is defined %}
 compression = "{{ item.compression }}"
-{%- endif %}
 
-{% if item.custom_compression_filter is defined -%}
+{%- endif %}
+{%- if item.custom_compression_filter is defined %}
 custom_compression_filter = "{{ item.custom_compression_filter }}"
-{%- endif %}
 
-{% if item.custom_decompression_filter is defined -%}
+{%- endif %}
+{% if item.custom_decompression_filter is defined %}
 custom_decompression_filter = "{{ item.custom_decompression_filter }}"
-{%- endif %}
 
-{% if item.immediate_checkpoint is defined -%}
+{%- endif %}
+{%- if item.immediate_checkpoint is defined %}
 immediate_checkpoint = "{{ item.immediate_checkpoint }}"
-{%- endif %}
 
-{% if item.last_backup_maximum_age is defined -%}
+{%- endif %}
+{%- if item.last_backup_maximum_age is defined %}
 last_backup_maximum_age = "{{ item.last_backup_maximum_age }}"
-{%- endif %}
 
-{% if item.minimum_redundancy is defined -%}
+{%- endif %}
+{%- if item.minimum_redundancy is defined %}
 minimum_redundancy = "{{ item.minimum_redundancy }}"
-{%- endif %}
 
-{% if item.network_compression is defined -%}
+{%- endif %}
+{%- if item.network_compression is defined %}
 network_compression = "{{ item.network_compression }}"
-{%- endif %}
 
-{% if item.post_archive_retry_script is defined -%}
+{%- endif %}
+{%- if item.post_archive_retry_script is defined %}
 post_archive_retry_script = "{{ item.post_archive_retry_script }}"
-{%- endif %}
 
-{% if item.post_archive_script is defined -%}
+{%- endif %}
+{%- if item.post_archive_script is defined %}
 post_archive_script = "{{ item.post_archive_script }}"
-{%- endif %}
 
-{% if item.post_backup_retry_script is defined -%}
+{%- endif %}
+{%- if item.post_backup_retry_script is defined %}
 post_backup_retry_script = "{{ item.post_backup_retry_script }}"
-{%- endif %}
 
-{% if item.post_backup_script is defined -%}
+{%- endif %}
+{%- if item.post_backup_script is defined %}
 post_backup_script = "{{ item.post_backup_script }}"
-{%- endif %}
 
-{% if item.pre_archive_retry_script is defined -%}
+{%- endif %}
+{%- if item.pre_archive_retry_script is defined %}
 pre_archive_retry_script = "{{ item.pre_archive_retry_script }}"
-{%- endif %}
 
-{% if item.pre_archive_script is defined -%}
+{%- endif %}
+{%- if item.pre_archive_script is defined %}
 pre_archive_script = "{{ item.pre_archive_script }}"
-{%- endif %}
 
-{% if item.pre_backup_retry_script is defined -%}
+{%- endif %}
+{%- if item.pre_backup_retry_script is defined %}
 pre_backup_retry_script = "{{ item.pre_backup_retry_script }}"
-{%- endif %}
 
-{% if item.pre_backup_script is defined -%}
+{%- endif %}
+{%- if item.pre_backup_script is defined %}
 pre_backup_script = "{{ item.pre_backup_script }}"
-{%- endif %}
 
-{% if item.recovery_options is defined -%}
+{%- endif %}
+{%- if item.recovery_options is defined %}
 recovery_options = "{{ item.recovery_options }}"
-{%- endif %}
 
-{% if item.retention_policy is defined -%}
+{%- endif %}
+{%- if item.retention_policy is defined %}
 retention_policy = "{{ item.retention_policy }}"
-{%- endif %}
 
-{% if item.retention_policy_mode is defined -%}
+{%- endif %}
+{%- if item.retention_policy_mode is defined %}
 retention_policy_mode = "{{ item.retention_policy_mode }}"
-{%- endif %}
 
-{% if item.tablespace_bandwidth_limit is defined -%}
+{%- endif %}
+{%- if item.tablespace_bandwidth_limit is defined %}
 tablespace_bandwidth_limit = "{{ item.tablespace_bandwidth_limit }}"
-{%- endif %}
 
-{% if item.wal_retention_policy is defined -%}
+{%- endif %}
+{%- if item.wal_retention_policy is defined %}
 wal_retention_policy = "{{ item.wal_retention_policy }}"
 {%- endif %}


### PR DESCRIPTION
Some improvements:
* Make it clearer in the generated config file that configuration is split between backups (either base backup via replication or rsync via ssh) and wal streaming (replication and/or traditional wal archiving)
* Fix backups via rsync (the config wasn't being generated with the correct settings even when the `barman_server_configuration` settings should have enabled it
* Allow overriding the ssh_command (to add `-q` when the server sends a banner on ssh connection for example)
* A few small changes to the whitespace of the generated template to avoid many empty lines in the config (aesthetics only)

Tested with rsync backups and streaming wal replication.